### PR TITLE
Lock Flask_pyoidc to v1.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ click
 csh_ldap>=2.0.2
 Flask
 Flask-Migrate
-Flask-pyoidc
+Flask-pyoidc==1.3.0
 Flask-Script
 Flask-SQLAlchemy
 gunicorn


### PR DESCRIPTION
Please update to v2 when possible, but this will fix the broken app in the meantime.