### PR TITLE
Fix additonally loaded quotes going to wrong link

### DIFF
--- a/quotefault/templates/bootstrap/additional_quotes.html
+++ b/quotefault/templates/bootstrap/additional_quotes.html
@@ -19,7 +19,7 @@
         </div>
         <div class="card-footer">
             Submitted by <a
-                href="https://profiles.csh.rit.edu/profile/{{ quote.submitter }}">{{ get_display_name(quote.submitter) }}</a>
+                href="https://profiles.csh.rit.edu/user/{{ quote.submitter }}">{{ get_display_name(quote.submitter) }}</a>
             on {{ quote.quote_time.strftime('%Y-%m-%d %H:%M:%S') }}
         </div>
     </div>


### PR DESCRIPTION
Quotes on the first loaded page don't have this issue, but when you load the rest of the quotes, opening the profile of the person who submitted it incorrectly links to profiles.csh.rit.edu/profiles/username instead of profiles.csh.rit.edu/user/username