### PR TITLE
Allow Mail to Use Any Server Name in Email

### DIFF
--- a/quotefault/mail.py
+++ b/quotefault/mail.py
@@ -21,8 +21,8 @@ def send_report_email(reporter, quote):
                 sender=app.config.get('MAIL_USERNAME'),
                 recipients=recipients)
     template = 'mail/report'
-    msg.body = render_template(template + '.txt', reporter = reporter, quote = quote )
-    msg.html = render_template(template + '.html', reporter = reporter, quote = quote )
+    msg.body = render_template(template + '.txt', reporter = reporter, quote = quote, server = app.config['SERVER_NAME'])
+    msg.html = render_template(template + '.html', reporter = reporter, quote = quote, server = app.config['SERVER_NAME'])
     mail_client.send(msg)
 
 def send_email(toaddr, subject, body):

--- a/quotefault/templates/mail/report.html
+++ b/quotefault/templates/mail/report.html
@@ -7,7 +7,7 @@
         <p>Report submitted by: {{reporter}}</p>
         <p>Quote being reported: {{quote.quote}} -{{quote.speaker}}</p>
         <p>Quote submitted by: {{quote.submitter}}</p>
-        <p>Please attend to this on the <a href="https://quotefault.csh.rit.edu/admin">QuoteFault Admin Page</a>!</p>
+        <p>Please attend to this on the <a href="https://{{server}}/admin">QuoteFault Admin Page</a>!</p>
     </div>
 {% endblock %}
 

--- a/quotefault/templates/mail/report.txt
+++ b/quotefault/templates/mail/report.txt
@@ -3,5 +3,5 @@ Hello EBoard/RTP
     Report submitted by: {{reporter}}
     Quote being reported: {{quote.quote}} -{{quote.speaker}}
     Quote submitted by: {{quote.submitter}}
-    Please attend to this on https://quotefault.csh.rit.edu/admin
+    Please attend to this on https://{{server}}/admin
 


### PR DESCRIPTION
Changes the server name in the contents of the report notification email to EBoard/RTPs to use the actual server name of the build (ex. if using dev, quotefault-dev.csh.rit.edu instead of a constant quotefault.csh.rit.edu.

Realized last night while @mxmeinhold was testing that I didn't add this as a thing while adding the report email, doesn't impact prod but without it dev is a little more annoying since you have to manually change/enter the link.