### PR TITLE
Stop Quotefault from Pointing to Dantay

### DIFF
--- a/quotefault/templates/bootstrap/base.html
+++ b/quotefault/templates/bootstrap/base.html
@@ -102,7 +102,7 @@
 <footer>
     <br>
     <div class="version">
-        <a class="footer-version" href="https://github.com/dantayy/quotefault">
+        <a class="footer-version" href="https://github.com/ComputerScienceHouse/quotefault">
             Quotefault ({{ metadata.version }})
         </a>
     </div>


### PR DESCRIPTION
The redirect at the Bottom of the page shows the right commit tag, but is redirecting to @dantayy 's fork of the project instead of the one owned by CSH.